### PR TITLE
Improve page structure for easier files including

### DIFF
--- a/templates-pre/sections/_skeleton-content.html
+++ b/templates-pre/sections/_skeleton-content.html
@@ -2,7 +2,18 @@
 <html lang="en-us">
 	<!-- HTML files with "_" as prefix will be not be converted as a page html 
 			 (check gulpfile.js file for the code) -->
-	{% include "sections/_head.html" %}
+	<head>
+		<title>{{ document_title }} | My Site</title>
+		<!-- Meta -->
+		<meta charset="UTF-8" />
+		<meta http-equiv="X-UA-Compatible" content="IE=edge" />
+		<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" />
+
+		<!-- CSS Files -->
+		<link rel="stylesheet" href="{{ css_path }}main.css" type="text/css" />
+		{% block include_head %}{% endblock %}
+		<!-- End CSS files -->
+	</head>
 	<!-- You can go through nunjucks documentation to use template engine syntax -->
 	<body>
 		<div class="page">
@@ -22,5 +33,6 @@
 		<!-- HTML script path -->
 		<script src="//mozilla.github.io/nunjucks/files/nunjucks.js" type="text/javascript"></script>
 		<script src="{{ js_path }}html.js" type="text/javascript"></script>
+		{% block include_footer %}{% endblock %}
 	</body>
 </html>


### PR DESCRIPTION
Hi. Please change structure of <em>skeleton-content.html</em> so people could include additional css and js files on selected pages (in <em>include_head</em> and <em>include_footer</em> blocks respectively).